### PR TITLE
Fix ImportError on app build in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This template is configured to work with Heroku out of the box - just make sure 
 
 * Build your Vue Application:
 ```
-$ python app build
+$ python -m app build
 ```
 This commands is a shorcut for cd-ing into `/app/client/vue_app` and running `$ npm run build`.
 


### PR DESCRIPTION
Running `python app build` on python 3.6 produces:
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "app/__main__.py", line 6, in <module>
    from .app.config import Config
ImportError: attempted relative import with no known parent package
```

Fixed using the -m flag.