### PR TITLE
Fix Heroku deploy

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,5 +16,13 @@
     }
    },
   "addons": [
-   ]
+   ],
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "heroku/python"
+    }
+  ]
 }


### PR DESCRIPTION
Hi @gtalarico - I noticed the Heroku Deploy Button was failing and this PR should fix it. I tested the Deploy Button using my fork, and it did not fail.

Details: Without explicitly specifying multiple buildpacks, Heroku will only choose one buildpack at deploy time. It chooses Python for this app, which means the `yarn build` (`postinstall` script) doesn't get executed. Adding the buildpacks explicitly to the `app.json` tells Heroku to run the build process for Python and then for Node during a Heroku Deploy Button deploy.

This change also makes the one-click Deploy Button match the Heroku CLI commands you have specified here https://github.com/gtalarico/flask-vuejs-template#production-sever-setup